### PR TITLE
Various furthsettins improvements

### DIFF
--- a/scss/modules/_index.sm.scss
+++ b/scss/modules/_index.sm.scss
@@ -1,3 +1,4 @@
 @use 'committee.sm' as *;
+@use 'link-gallery.sm' as *;
 @use 'nav.sm' as *;
 

--- a/scss/modules/_link-gallery.scss
+++ b/scss/modules/_link-gallery.scss
@@ -1,19 +1,37 @@
 .link-gallery {
-  display: grid;
-  grid-template-columns: repeat(var(--grid-column-count), var(--grid-column-width));
-  gap: var(--grid-gutter-width);
   padding-block: var(--spacing-block-md);
+
   --gallery-item-column-span: 1;
   --gallery-row-image-height: 12rem;
   --gallery-row-title-height: fit-content;
-  text-align: center;
 
-  li {
-    list-style-type: none;
-    grid-column: span var(--gallery-item-column-span);
+  &:not(.link-gallery--splash-first) {
+    display: grid;
+    grid-template-columns: repeat(var(--grid-column-count), var(--grid-column-width));
+    gap: var(--grid-gutter-width);
+
+    li {
+      list-style-type: none;
+      grid-column: span var(--gallery-item-column-span);
+
+      :is(&.link-gallery__container, & .link-gallery__container) {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: var(--gallery-row-image-height) var(--gallery-row-title-height);
+        row-gap: var(--spacing-block-sm);
+      }
+
+      .link-gallery__title {
+        width: 100%;
+        height: min-content;
+        text-align: center;
+        margin-inline: var(--spacing-inline-xs);
+      }
+    }
   }
 
   img {
+    display: block;
     max-width: 50%;
     max-height: 100%;
     height: fit-content;
@@ -22,22 +40,33 @@
   }
 }
 
-.link-gallery__container {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: var(--gallery-row-image-height) var(--gallery-row-title-height);
-  row-gap: var(--spacing-block-sm);
-}
-
 .link-gallery--furthsettins img {
   box-sizing: border-box;
   border-radius: 50%;
   border: solid var(--border-width) var(--text-color);
 }
 
-.link-gallery__title {
-  width: 100%;
-  height: min-content;
-  text-align: center;
-  margin-inline: var(--spacing-inline-xs);
+.link-gallery--splash-first {
+  .link-gallery__container {
+    display: block;
+    width: fit-content;
+  }
+
+  li:first-of-type {
+    list-style-type: none;
+
+    :is(&.link-gallery__container, & .link-gallery__container) {
+      width: 100%;
+    }
+
+    .link-gallery__title {
+      text-align: center;
+    }
+  }
+
+  li + li {
+    margin-block-start: var(--spacing-block-lg);
+    margin-inline-start: 1em;
+  }
 }
+

--- a/scss/modules/_link-gallery.scss
+++ b/scss/modules/_link-gallery.scss
@@ -14,8 +14,9 @@
   }
 
   img {
-    max-width: 100%;
+    max-width: 50%;
     max-height: 100%;
+    height: fit-content;
     margin: auto;
     object-fit: contain;
   }

--- a/scss/modules/_link-gallery.sm.scss
+++ b/scss/modules/_link-gallery.sm.scss
@@ -1,0 +1,4 @@
+.link-gallery {
+  --gallery-item-column-span: 3;
+}
+

--- a/scss/modules/_link-gallery.xs.scss
+++ b/scss/modules/_link-gallery.xs.scss
@@ -1,25 +1,46 @@
 .link-gallery {
-  grid-auto-rows: calc(
-    var(--gallery-row-image-height) +
-    var(--spacing-block-sm) +
-    var(--gallery-row-title-height)
-  );
   --gallery-item-column-span: 2;
   --gallery-row-title-height: 11ex;
-  text-align: center;
+
+  &:not(.link-gallery--splash-first) {
+    grid-auto-rows: calc(
+      var(--gallery-row-image-height) +
+      var(--spacing-block-sm) +
+      var(--gallery-row-title-height)
+    );
+
+    .link-gallery__title {
+      width: 100%;
+      height: 9.9ex;
+      height: 3lh;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
 
   img {
     max-width: 100%;
   }
 }
 
-.link-gallery__title {
-  width: 100%;
-  height: 9.9ex;
-  height: 3lh;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+.link-gallery--splash-first li:first-of-type {
+  :is(&.link-gallery__container, & .link-gallery__container) {
+    display: grid;
+    grid-template-columns: repeat(var(--grid-column-count), var(--grid-column-width));
+    gap: var(--grid-gutter-width);
+  }
+
+  img {
+    grid-column: span 2;
+  }
+
+  .link-gallery__title {
+    grid-column: span calc(var(--grid-prose-column-count) - 2);
+    align-self: center;
+    text-align: start;
+  }
 }
+

--- a/scss/modules/_link-gallery.xs.scss
+++ b/scss/modules/_link-gallery.xs.scss
@@ -7,6 +7,10 @@
   --gallery-item-column-span: 2;
   --gallery-row-title-height: 11ex;
   text-align: center;
+
+  img {
+    max-width: 100%;
+  }
 }
 
 .link-gallery__title {

--- a/src/components/LallansIssuesGallery.astro
+++ b/src/components/LallansIssuesGallery.astro
@@ -10,19 +10,37 @@ const issues = (await getAllLallansIssues()).sort(issueNumberDescending);
 function issueNumberDescending(issue1: LallansIssue, issue2: LallansIssue) {
   return issue2.issueNumber - issue1.issueNumber;
 }
+
+const mostRecentIssue = issues[0];
+const allOtherIssues = issues.slice(1);
 ---
 
-<ul class="link-gallery">
+<ul class="link-gallery link-gallery--splash-first">
+  <li>
+    <a
+      class="link-gallery__container"
+      href={`/${locale}/furthsettins/lallans/${mostRecentIssue.issueNumber}`}
+    >
+      <Image src={mostRecentIssue.img.width192} alt="" />
+      <p class="link-gallery__title">
+        Lallans {mostRecentIssue.issueNumber}
+        <br />
+        <small>{mostRecentIssue.issueName}</small>
+      </p>
+    </a>
+  </li>
+
   {
-    issues.map(async (issue) => (
+    allOtherIssues.map((issue) => (
       <li>
         <a
           class="link-gallery__container"
           href={`/${locale}/furthsettins/lallans/${issue.issueNumber}`}
         >
-          <Image src={issue.img.width192} alt="" />
           <p class="link-gallery__title">
-            Lallans {issue.issueNumber} | {issue.issueName}
+            Lallans {issue.issueNumber}
+            <br />
+            <small>{issue.issueName}</small>
           </p>
         </a>
       </li>

--- a/src/data/lallans/issue100.ts
+++ b/src/data/lallans/issue100.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 222',
+  issueName: 'Simmer 2022',
   price: '10.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue101.ts
+++ b/src/data/lallans/issue101.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 222',
+  issueName: 'Yuil 2022',
   price: '10.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue56.ts
+++ b/src/data/lallans/issue56.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Voar 200',
+  issueName: 'Voar 2000',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue57.ts
+++ b/src/data/lallans/issue57.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 200',
+  issueName: 'Hairst 2000',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue59.ts
+++ b/src/data/lallans/issue59.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 201',
+  issueName: 'Hairst 2001',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue60.ts
+++ b/src/data/lallans/issue60.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 202',
+  issueName: 'Ware 2002',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue61.ts
+++ b/src/data/lallans/issue61.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 202',
+  issueName: 'Hairst 2002',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue62.ts
+++ b/src/data/lallans/issue62.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 203',
+  issueName: 'Ware 2003',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue63.ts
+++ b/src/data/lallans/issue63.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 203',
+  issueName: 'Hairst 2003',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue64.ts
+++ b/src/data/lallans/issue64.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 204',
+  issueName: 'Ware 2004',
   price: '7.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue65.ts
+++ b/src/data/lallans/issue65.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 204',
+  issueName: 'Hairst 2004',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue66.ts
+++ b/src/data/lallans/issue66.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 205',
+  issueName: 'Ware 2005',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue67.ts
+++ b/src/data/lallans/issue67.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Hairst 205',
+  issueName: 'Hairst 2005',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue68.ts
+++ b/src/data/lallans/issue68.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 206',
+  issueName: 'Ware 2006',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue69.ts
+++ b/src/data/lallans/issue69.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Wunter 206',
+  issueName: 'Wunter 2006',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue70.ts
+++ b/src/data/lallans/issue70.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Ware 207',
+  issueName: 'Ware 2007',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue71.ts
+++ b/src/data/lallans/issue71.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Wunter 208',
+  issueName: 'Wunter 2008',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue72.ts
+++ b/src/data/lallans/issue72.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 208',
+  issueName: 'Simmer 2008',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue73.ts
+++ b/src/data/lallans/issue73.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Wunter 209',
+  issueName: 'Wunter 2009',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue74.ts
+++ b/src/data/lallans/issue74.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 209',
+  issueName: 'Simmer 2009',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue75.ts
+++ b/src/data/lallans/issue75.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 209',
+  issueName: 'Yuil 2009',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue76.ts
+++ b/src/data/lallans/issue76.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 210',
+  issueName: 'Simmer 2010',
   price: '8.50',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue77.ts
+++ b/src/data/lallans/issue77.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 210',
+  issueName: 'Yuil 2010',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue78.ts
+++ b/src/data/lallans/issue78.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 211',
+  issueName: 'Simmer 2011',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue79.ts
+++ b/src/data/lallans/issue79.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 211',
+  issueName: 'Yuil 2011',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue80.ts
+++ b/src/data/lallans/issue80.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 212',
+  issueName: 'Simmer 2012',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue81.ts
+++ b/src/data/lallans/issue81.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 212',
+  issueName: 'Yuil 2012',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue82.ts
+++ b/src/data/lallans/issue82.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 213',
+  issueName: 'Simmer 2013',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue83.ts
+++ b/src/data/lallans/issue83.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 213',
+  issueName: 'Yuil 2013',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue84.ts
+++ b/src/data/lallans/issue84.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 214',
+  issueName: 'Simmer 2014',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue85.ts
+++ b/src/data/lallans/issue85.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 214',
+  issueName: 'Yuil 2014',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue86.ts
+++ b/src/data/lallans/issue86.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 215',
+  issueName: 'Simmer 2015',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue87.ts
+++ b/src/data/lallans/issue87.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 215',
+  issueName: 'Yuil 2015',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue88.ts
+++ b/src/data/lallans/issue88.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 216',
+  issueName: 'Simmer 2016',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue89.ts
+++ b/src/data/lallans/issue89.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 216',
+  issueName: 'Yuil 2016',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue90.ts
+++ b/src/data/lallans/issue90.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 217',
+  issueName: 'Simmer 2017',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue91.ts
+++ b/src/data/lallans/issue91.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 217',
+  issueName: 'Yuil 2017',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue92.ts
+++ b/src/data/lallans/issue92.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 218',
+  issueName: 'Simmer 2018',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue93.ts
+++ b/src/data/lallans/issue93.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 218',
+  issueName: 'Yuil 2018',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue96.ts
+++ b/src/data/lallans/issue96.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 220',
+  issueName: 'Simmer 2020',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue97.ts
+++ b/src/data/lallans/issue97.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 220',
+  issueName: 'Yuil 2020',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue98.ts
+++ b/src/data/lallans/issue98.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Simmer 221',
+  issueName: 'Simmer 2021',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {

--- a/src/data/lallans/issue99.ts
+++ b/src/data/lallans/issue99.ts
@@ -8,7 +8,7 @@ const issue: LallansIssue = {
     width192: img192w,
     width274: img274w,
   },
-  issueName: 'Yuil 221',
+  issueName: 'Yuil 2021',
   price: '9.00',
   uploadDate: '2023-08-25',
   description: {


### PR DESCRIPTION
* Locks 1:1 aspect ratio of furthsettins images at `/[locale]/furthsettins`
* Adds a `--splash-first` variant of the `link-gallery` CSS module, which renders the first item as a 'splash' with an image and the rest as basic text list items
* Renders the Lallans gallery as a splash-first link gallery
* Fixes mis-typed years in Lallans issue data